### PR TITLE
fix: change tabs styles

### DIFF
--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -114,6 +114,21 @@ $block: #{$fd-namespace}-tabs;
     line-height: 1rem;
     padding: $fd-tabs-link-padding-y $fd-tabs-item-padding-x;
 
+    &.is-selected {
+      .fd-tabs__tag::after {
+        background-color: var(--fdTabs_Selected_Color);
+      }
+
+      .fd-tabs__icon {
+        color: var(--fdTabs_Selected_Icon_Color, var(--sapContent_ContrastIconColor));
+        background-color: var(--fdTabs_Selected_Color);
+
+        &::after {
+          background-color: var(--fdTabs_Selected_Color);
+        }
+      }
+    }
+
     @include fd-focus() {
       box-shadow: none;
       outline: none;


### PR DESCRIPTION
## Related Issue
Closes SAP/fundamental-styles#

## [Description](https://github.com/SAP/fundamental-ngx/issues/5128)

{{ _Enter short description of the change_ }}

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.
>
> To see examples of which screenshots to include, go to [Screenshot Examples](https://github.com/SAP/fundamental-styles/wiki/Pull-Request-Screenshot-Examples).

### Before:


### After:

#### Please check whether the PR fulfills the following requirements

1. The output matches the design specs
- [x] All values are in `rem`
- [x] Text elements follow the truncation rules
- [x] hover state of the element follow design spec
- [x] focus state of the element follow design spec
- [x] active state of the element follow design spec
- [x] selected state of the element follow design spec
- [x] selected hover state of the element follow design spec
- [x] pressed state of the element follow design spec
- [x] Responsiveness rules - the component has modifier classes for all breakpoints
- [x] Includes Compact/Cosy/Tablet design
- [n/a] RTL support
2. The code follows fundamental-styles code standards and style
- [x] only one top level `fd-*` class is used in the file
- [x] BEM naming convention is used
- [x] Mixins are used for repeatable code (`fd-rtl`, `fd-ellipsis`, `fd-flex`, `fd-selected`, `fd-focus`, ect.)
- [n/a] A11y support - keyboard support, screenreader support, proper ARIA attributes, etc.
- [x] `fd-reset()` mixin is applied to all elements
- [x] Variables are used, if some value is used more than twice.
- [x] Checked if current components can be reused, instead of having new code.
3. Testing
- [a] tested Storybook examples with "CSS Resources" `normalize` option 
- [n/a] tested Storybook examples with "CSS Resources" `unnormalize` option 
- [n/a] Verified all styles in IE11
- [n/a] Updated tests
- [n/a] last commit message should have `[ci visual]` so it can trigger chromatic visual regression (e.g. `test: run chromatic visual regression [ci visual]`)
4. Documentation
- [n/a] Storybook documentation has been created/updated
- [n/a] Breaking Changes [wiki](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes) has been updated in case of breaking changes.
